### PR TITLE
Bump commons-io from 2.6 to 2.7 in /monkey-api-encrypt-core

### DIFF
--- a/monkey-api-encrypt-core/pom.xml
+++ b/monkey-api-encrypt-core/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.6</version>
+			<version>2.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>


### PR DESCRIPTION
Bumps commons-io from 2.6 to 2.7.

Signed-off-by: dependabot[bot] <support@github.com>